### PR TITLE
Use if instead of && in git hooks (#680)

### DIFF
--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 local_hook="$HOME"/.git_template.local/hooks/post-checkout
-[ -f "$local_hook" ] && . "$local_hook"
+
+if [ -f "$local_hook" ]; then
+  . "$local_hook";
+fi
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 local_hook="$HOME"/.git_template.local/hooks/post-commit
-[ -f "$local_hook" ] && . "$local_hook"
+
+if [ -f "$local_hook" ]; then
+  . "$local_hook";
+fi
 
 .git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 local_hook="$HOME"/.git_template.local/hooks/post-merge
-[ -f "$local_hook" ] && . "$local_hook"
+
+if [ -f "$local_hook" ]; then
+  . "$local_hook";
+fi
 
 .git/hooks/ctags >/dev/null 2>&1 &


### PR DESCRIPTION
This prevents a Git hook from issuing a non-zero exit status if the condition is the last line of the hook.